### PR TITLE
Fix macOS install script: follow HTTP redirect when fetching binary

### DIFF
--- a/scripts/install-latest-darwin-amd64.sh
+++ b/scripts/install-latest-darwin-amd64.sh
@@ -33,8 +33,7 @@ fi
 mark_pass
 
 echo -n "Fetching binary... "
-ZIP_ACTUAL_URL=`curl -s -I ${ZIP_URL} | grep "^Location: " | sed -n -e 's/^Location: //p' | tr -d '\r\n'`
-curl -s ${ZIP_ACTUAL_URL} > ${TMP_DIR}/${ZIP_FILENAME}
+curl -sL ${ZIP_URL} > ${TMP_DIR}/${ZIP_FILENAME}
 mark_pass
 
 echo -n "Extacting binary... "


### PR DESCRIPTION
I noticed the macOS install script fails because the `grep` doesn't find a match anymore. My change fixes this by using the `curl --location` option, which I think is the recommended way to follow a HTTP redirect.