### PR TITLE
Reference specific version of tealeg/xlsx to fix go get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ replace (
 require (
 	github.com/aotimme/gocsv/cmd v0.0.0
 	github.com/aotimme/gocsv/csv v0.0.0
+	github.com/tealeg/xlsx v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,16 @@
 github.com/alphagov/router v0.0.0-20161125164013-5d98b0d9fc19 h1:LX9H/VztLww9xtRK5O1coSCiRkF0UqLZytIMzg8CYUU=
 github.com/alphagov/router v0.0.0-20161125164013-5d98b0d9fc19/go.mod h1:Mp21fDX6h4wMwSzsItDP+UtNLAlQOZZIXu6/YsyQae0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-sqlite3 v1.0.1-0.20150807032509-0fa27b5cb05c h1:zs99zFsZn1DKeW4wkNZjFxNC4lWawORDE6IFej7do9A=
 github.com/mattn/go-sqlite3 v1.0.1-0.20150807032509-0fa27b5cb05c/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/tealeg/xlsx v0.0.0-20161026161224-a8490cf686de h1:PC5Hwqy6Muk6JOroE699iNIxzZLlnls3iEDXbClQsKc=
 github.com/tealeg/xlsx v0.0.0-20161026161224-a8490cf686de/go.mod h1:uxu5UY2ovkuRPWKQ8Q7JG0JbSivrISjdPzZQKeo74mA=
+github.com/tealeg/xlsx v1.0.5 h1:+f8oFmvY8Gw1iUXzPk+kz+4GpbDZPK1FhPiQRd+ypgE=
+github.com/tealeg/xlsx v1.0.5/go.mod h1:btRS8dz54TDnvKNosuAqxrM1QgN1udgk9O34bDCnORM=
 golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045/go.mod h1:cYlCBUl1MsqxdiKgmc4uh7TxZfWSFLOGSRR090WDxt8=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
We could fix #22 by pinning the required version of tealeg/xlsx. Updating to a more recent version (and tackling breaking changes) could still be done in a separate issue.