### PR TITLE
Fix build on non-64-bit systems

### DIFF
--- a/cmd/in_memory_csv.go
+++ b/cmd/in_memory_csv.go
@@ -636,7 +636,7 @@ func (scs *StringColumnStats) CalculateAllStats() {
 }
 
 func (scs *StringColumnStats) CalculateMaxLength() {
-	scs.maxLength = math.MinInt64
+	scs.maxLength = -1
 	for _, elem := range scs.array {
 		if len(elem) > scs.maxLength {
 			scs.maxLength = len(elem)


### PR DESCRIPTION
This minor change would address an issue with building on architectures different from 64-bit. I encountered this trying to use xgo to cross compile.
I don't think this change has any bad side effects.