### PR TITLE
Build packages for distribution using `xgo`

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -13,18 +13,20 @@ When developing, you can build a local version of the `gocsv` binary via running
 
 To release an update to `gocsv`, make sure you have committed and pushed the most recent commit on master. Then:
 
-1. Tag the latest commit as "latest":
+1. Tag the latest commit as "latest".
 
    ```shell
    make tag
    ```
 
-2. Create binaries for distribution:
+
+2. Create cross-compiled binaries for distribution. Cross-compilation uses [xgo](https://github.com/karalabe/xgo) to handle issues with CGO packages in other platforms and architectures. Because `xgo` requires `docker`, you will need `docker` installed.
 
    ```shell
+   go get -u github.com/karalabe/xgo
    make dist
    ```
 
-   This will create zip files in the `dist` directory holding the `gocsv` binaries for various platforms and architectures. It relies on [xgo](https://github.com/karalabe/xgo) to faithfully cross-compile.
+   This will create zip files in the `dist` directory holding the `gocsv` binaries for various platforms and architectures.
 
 3. Upload the newly created distribution binaries to the [Latest Release](https://github.com/aotimme/gocsv/releases/tag/latest) page. You will need to [edit](https://github.com/aotimme/gocsv/releases/edit/latest) the release, remove the existing zip files, and upload the recently created zip files in `dist/`.

--- a/DEV.md
+++ b/DEV.md
@@ -25,6 +25,6 @@ To release an update to `gocsv`, make sure you have committed and pushed the mos
    make dist
    ```
 
-   This will create zip files in the `dist` directory holding the `gocsv` binaries for Linux, Unix, and Windows.
+   This will create zip files in the `dist` directory holding the `gocsv` binaries for various platforms and architectures. It relies on [xgo](https://github.com/karalabe/xgo) to faithfully cross-compile.
 
 3. Upload the newly created distribution binaries to the [Latest Release](https://github.com/aotimme/gocsv/releases/tag/latest) page. You will need to [edit](https://github.com/aotimme/gocsv/releases/edit/latest) the release, remove the existing zip files, and upload the recently created zip files in `dist/`.

--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ To enable debugging mode when running a `gocsv` command, specify the `--debug` c
 
 ## Installation
 
-For the latest pre-built binaries, see the [Latest Release](https://github.com/aotimme/gocsv/releases/tag/latest) page.
+For the latest pre-built binaries, cross-compiled using [xgo](https://github.com/karalabe/xgo), see the [Latest Release](https://github.com/aotimme/gocsv/releases/tag/latest) page.
 
 ### Apple OS X
 
@@ -754,13 +754,13 @@ This will install `gocsv` at `/usr/local/bin/gocsv`.
 
 #### Detailed Version
 
-To install the pre-built binary for Apple OS X, download the `gocsv-darwin-amd64.zip` file. It should download into your `~/Downloads` directory. To install it, open a Terminal window and do the following:
+To install the pre-built binary for Apple OS X, download the `gocsv-darwin-10.6-amd64.zip` file. It should download into your `~/Downloads` directory. To install it, open a Terminal window and do the following:
 
 ```shell
 cd ~/Downloads
-unzip gocsv-darwin-amd64.zip
-mv gocsv-darwin-amd64/gocsv /usr/local/bin
-rmdir gocsv-darwin-amd64
+unzip gocsv-darwin-10.6-amd64.zip
+mv gocsv-darwin-10.6-amd64/gocsv /usr/local/bin
+rmdir gocsv-darwin-10.6-amd64
 ```
 
 To verify that it has installed, open a _new_ Terminal window and run

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+BUILD_DIR=$(pwd)/build
 DIST_DIR=$(pwd)/dist
 EXECUTABLE=gocsv
 
@@ -7,20 +8,34 @@ GIT_HASH=$(git rev-parse HEAD)
 VERSION=$(cat VERSION)
 LD_FLAGS="-X github.com/aotimme/gocsv/cmd.VERSION=${VERSION} -X github.com/aotimme/gocsv/cmd.GIT_HASH=${GIT_HASH}"
 
+rm -rf ${BUILD_DIR}
+mkdir ${BUILD_DIR}
+
 rm -rf ${DIST_DIR}
 mkdir ${DIST_DIR}
-for os in darwin windows linux; do
-  for arch in amd64; do
-    basename=gocsv-${os}-${arch}
-    mkdir ${DIST_DIR}/${basename}
-    if [ "${os}" == "windows" ]; then
-      binary="${EXECUTABLE}.exe"
-    else
-      binary=${EXECUTABLE}
-    fi
-    env GOOS=${os} GOARCH=${arch} GO111MODULE=on go build -ldflags "${LD_FLAGS}" -o ${DIST_DIR}/${basename}/${binary}
-    cd ${DIST_DIR} && zip -rq ${basename}.zip ${basename}
-    cd ~-
-    rm -r ${DIST_DIR}/${basename}
-  done
+
+cd ${BUILD_DIR}
+# Use `xgo` to truly handle cross-compiling, mainly due to gocsv's dependency
+# on `go-sqlite3`, which is a cgo package.
+# See: https://github.com/mattn/go-sqlite3#cross-compile
+xgo -ldflags "${LD_FLAGS}" github.com/aotimme/gocsv
+
+# Move files to `dist` and zip them.
+for file in $(ls);
+do
+  folder=${file}
+  binary=${EXECUTABLE}
+  if [ ${file: -4} == ".exe" ];
+  then
+    binary="${EXECUTABLE}.exe"
+    folder=$(echo ${folder} | sed -E 's/.exe$//g')
+  fi
+  mkdir ${DIST_DIR}/${folder}
+  mv ${file} ${DIST_DIR}/${folder}/${binary}
+  cd ${DIST_DIR}
+  zip -rq ${folder}.zip ${folder}
+  rm -r ${folder}
+  cd ${BUILD_DIR}
 done
+
+rm -r ${BUILD_DIR}

--- a/scripts/install-latest-darwin-amd64.sh
+++ b/scripts/install-latest-darwin-amd64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BINARY_DIRNAME="gocsv-darwin-amd64"
+BINARY_DIRNAME="gocsv-darwin-10.6-amd64"
 ZIP_FILENAME="${BINARY_DIRNAME}.zip"
 ZIP_URL="https://github.com/aotimme/gocsv/releases/download/latest/${ZIP_FILENAME}"
 TMP_DIR=$(mktemp -d)


### PR DESCRIPTION
This follows a suggestion from @flowrean in #18 to use `xgo` for cross-compiling the `gocsv` binary for distribution.

In general this works well and should allow the `sql` subcommand (which depends on the [go-sqlite3](https://github.com/mattn/go-sqlite3) package) to work on other platforms and architectures. It also provides more platforms and architectures than the whitelisted set previously provided.

I have only tested the Mac binary (`darwin` and `amd64`) on my local machine and the Linux binary (`linux` and `amd64`) on the `alpine:3.12.0` and `ubuntu:12.04` Docker images.

On my Mac, everything works with the `xgo` compiled version of `gocsv`.

With Linux, all subcommands now work on the `ubuntu` image, including `sql` which previously did not work. However, there is a regression in that the `xgo`-built `gocsv` does not work at all on `alpine`, whereas previously all subcommands except the `sql` subcommand worked.

The issue I ran into with `alpine` was (after `docker cp`-ing a CSV and the cross-compiled `gocsv` binary into an interactive terminal in the `alpine` container):
```
/ # ./gocsv view tmp.csv
/bin/sh: ./gocsv: not found
```
This may be a duplicate of karalabe/xgo#183 (i.e. `xgo` may not support `alpine`). Regardless, I'm not too worried about it. I doubt people will be using `gocsv` in a container based on `alpine`, and if they are they can compile it themselves IMO.

I have not tested the Windows binaries, which would be helpful to determine if this can close the issue #18.

Here are the zip files that it now creates via `xgo`, which I'm fine with publishing in the release(s):
```
$ ls dist
gocsv-android-16-386.zip
gocsv-android-16-aar.zip
gocsv-android-16-arm.zip
gocsv-darwin-10.6-386.zip
gocsv-darwin-10.6-amd64.zip
gocsv-ios-5.0-arm64.zip
gocsv-ios-5.0-armv7.zip
gocsv-ios-5.0-framework.zip
gocsv-linux-386.zip
gocsv-linux-amd64.zip
gocsv-linux-arm-5.zip
gocsv-linux-arm-6.zip
gocsv-linux-arm-7.zip
gocsv-linux-arm64.zip
gocsv-linux-mips.zip
gocsv-linux-mips64.zip
gocsv-linux-mips64le.zip
gocsv-linux-mipsle.zip
gocsv-windows-4.0-386.zip
gocsv-windows-4.0-amd64.zip
```