### PR TITLE
Allow changing the default delimiter via the `GOCSV_DELIMITER` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ curl -s https://raw.githubusercontent.com/aotimme/gocsv/latest/scripts/install-l
 - [Specifying Columns](#specifying-columns)
 - [Regular Expression Syntax](#regular-expression-syntax)
 - [Pipelining](#pipelining)
+- [Changing the Default Delimiter](#changing-the-default-delimiter)
 - [Examples](#examples)
 - [Debugging](#debugging)
 - [Installation](#installation)
@@ -650,6 +651,24 @@ cat test-files/left-table.csv \
 &#x2020; `stack` and `sql` read from standard input when specifying the filename as `-`.
 
 &#x2021; `xlsx` sends output to standard out when using the `--sheet` flag.
+
+## Changing the Default Delimiter
+
+While `gocsv` generally assumes standard CSVs (per [RFC 4180](https://tools.ietf.org/html/rfc4180)), you can specify a default delimiter other than `,` using the `GOCSV_DELIMITER` environment variable.
+
+For example, to use semicolon-delimited files:
+
+```shell
+export GOCSV_DELIMITER=";"
+gocsv select -c 1 semicolon-delimited.scsv
+```
+
+Or, to use tab-delimited files (TSVs):
+
+```shell
+export GOCSV_DELIMITER="\t"
+gocsv select -c 1 tab-delimited.tsv
+```
 
 ## Examples
 

--- a/cmd/delimiter.go
+++ b/cmd/delimiter.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"flag"
 	"io"
-	"unicode/utf8"
 )
 
 type DelimiterSubcommand struct {
@@ -33,22 +32,18 @@ func (sub *DelimiterSubcommand) Run(args []string) {
 }
 
 func ChangeDelimiter(inputCsv *InputCsv, inputDelimiter, outputDelimiter string) {
-	if inputDelimiter == "\\t" {
-		inputCsv.SetDelimiter('\t')
-	} else if len(inputDelimiter) > 0 {
-		delimiterRune, _ := utf8.DecodeRuneInString(inputDelimiter)
-		inputCsv.SetDelimiter(delimiterRune)
+	inputDelimiterRune := GetDelimiterFromString(inputDelimiter)
+	if inputDelimiterRune != rune(0) {
+		inputCsv.SetDelimiter(inputDelimiterRune)
 	}
 	// Be lenient when reading in the file.
 	inputCsv.SetFieldsPerRecord(-1)
 	inputCsv.SetLazyQuotes(true)
 
 	outputCsv := NewOutputCsvFromInputCsv(inputCsv)
-	if outputDelimiter == "\\t" {
-		outputCsv.SetDelimiter('\t')
-	} else if len(outputDelimiter) > 0 {
-		delimiterRune, _ := utf8.DecodeRuneInString(outputDelimiter)
-		outputCsv.SetDelimiter(delimiterRune)
+	outputDelimiterRune := GetDelimiterFromString(outputDelimiter)
+	if outputDelimiterRune != rune(0) {
+		outputCsv.SetDelimiter(outputDelimiterRune)
 	}
 
 	// Write all rows with tabs.

--- a/cmd/input_csv.go
+++ b/cmd/input_csv.go
@@ -30,6 +30,10 @@ func NewInputCsv(filename string) (ic *InputCsv, err error) {
 	}
 	ic.bufReader = bufio.NewReader(ic.file)
 	ic.reader = csv.NewReader(ic.bufReader)
+	delimiter := os.Getenv("GOCSV_DELIMITER")
+	if delimiter != "" {
+		ic.reader.Comma = GetDelimiterFromString(delimiter)
+	}
 	err = ic.handleBom()
 	return
 }

--- a/cmd/output_csv.go
+++ b/cmd/output_csv.go
@@ -46,7 +46,10 @@ func NewOutputCsv() (oc *OutputCsv) {
 
 func NewOutputCsvFromFile(file *os.File) (oc *OutputCsv) {
 	oc = new(OutputCsv)
-	oc.writer = csv.NewWriter(file)
+	delimiter := os.Getenv("GOCSV_DELIMITER")
+	if delimiter != "" {
+		oc.writer.Comma = GetDelimiterFromString(delimiter)
+	}
 	return
 }
 

--- a/cmd/output_csv.go
+++ b/cmd/output_csv.go
@@ -46,6 +46,7 @@ func NewOutputCsv() (oc *OutputCsv) {
 
 func NewOutputCsvFromFile(file *os.File) (oc *OutputCsv) {
 	oc = new(OutputCsv)
+	oc.writer = csv.NewWriter(file)
 	delimiter := os.Getenv("GOCSV_DELIMITER")
 	if delimiter != "" {
 		oc.writer.Comma = GetDelimiterFromString(delimiter)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/aotimme/gocsv/csv"
 )
@@ -16,6 +17,16 @@ const (
 	BOM_STRING    = "\uFEFF"
 	NUM_BOM_BYTES = 3
 )
+
+func GetDelimiterFromString(delimiter string) rune {
+	if delimiter == "\\t" {
+		return '\t'
+	} else if len(delimiter) > 0 {
+		delimiterRune, _ := utf8.DecodeRuneInString(delimiter)
+		return delimiterRune
+	}
+	return rune(0)
+}
 
 // GetIndicesForColumnsOrPanic is a simple wrapper around GetIndicesForColumns
 // that will simply panic if GetIndicesForColumns returns an error.

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -57,3 +57,25 @@ func TestGetBaseFilenameWithoutExtension(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDelimiterFromString(t *testing.T) {
+	testCases := []struct {
+		delimiter string
+		comma     rune
+	}{
+		{",", ','},
+		{";", ';'},
+		{"\\t", '\t'},
+		{"", rune(0)},
+		{"|", '|'},
+		{"lolcats", 'l'},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.delimiter, func(t *testing.T) {
+			delimiterRune := GetDelimiterFromString(tt.delimiter)
+			if delimiterRune != tt.comma {
+				t.Errorf("Expected \"%#U\" but got \"%#U\"", tt.comma, delimiterRune)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This would address #19.

e.g.
```bash
export GOCSV_DELIMITER=";"
gocsv view semicolon-delimited-file.scsv
```