### PR TITLE
Fix base filepath: use OS-dependent path separator

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -184,8 +184,8 @@ func (rs *RowSorter) Less(i, j int) bool {
 }
 
 func GetBaseFilenameWithoutExtension(filename string) string {
-	baseFilename := path.Base(filename)
-	extension := path.Ext(baseFilename)
+	baseFilename := filepath.Base(filename)
+	extension := filepath.Ext(baseFilename)
 	return strings.TrimSuffix(baseFilename, extension)
 }
 


### PR DESCRIPTION
While checking #32 and testing the `sql` subcommand on Windows, I noticed an issue with file paths:
```shell
> .\gocsv.exe sql -q "SELECT COUNT(*) FROM abc" abc.csv
COUNT(*)
2
> .\gocsv.exe sql -q "SELECT COUNT(*) FROM abc" .\abc.csv
Error: no such table: abc
```
By running `SELECT * FROM sqlite_master WHERE type='table'` it is confirmed that the table is actually named `.\abc` in the last case. So getting the base path does not work on Windows.
This is easily solved by importing `path/filepath` instead of `path` to make the path separator platform dependent.