### PR TITLE
Update escaping of SQL table and column names

### DIFF
--- a/cmd/sql_test.go
+++ b/cmd/sql_test.go
@@ -44,3 +44,25 @@ func TestRunSql(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeSqlName(t *testing.T) {
+	testCases := []struct {
+		inputName  string
+		outputName string
+	}{
+		{"basic", "\"basic\""},
+		{"single space", "\"single space\""},
+		{"single'quote", "\"single'quote\""},
+		{"square[]brackets", "\"square[]brackets\""},
+		{"\"alreadyquoted\"", "\"\"\"alreadyquoted\"\"\""},
+		{"middle\"quote", "\"middle\"\"quote\""},
+	}
+	for i, tt := range testCases {
+		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			output := escapeSqlName(tt.inputName)
+			if output != tt.outputName {
+				t.Errorf("Expected %s but got %s", tt.outputName, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When populating the SQLite database for the `sql` subcommand, we were not appropriately escaping column (and table) names to handle names with escape characters (specifically `[` or `]`).

Fixes #36