### PR TITLE
add GOCSV_TIMELAYOUT env var; add inference details to README; tweak dependent subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For other platforms, see the [Installation](#installation) section.
 - [Regular Expression Syntax](#regular-expression-syntax)
 - [Pipelining](#pipelining)
 - [Changing the Default Delimiter](#changing-the-default-delimiter)
+- [Inference](#inference)
 - [Examples](#examples)
 - [Debugging](#debugging)
 - [Installation](#installation)
@@ -225,7 +226,7 @@ Arguments:
 
 ### describe
 
-Get basic information about a CSV. This will output the number of rows and columns in the CSV, the column headers in the CSV, and the inferred type of each column.
+Get basic information about a CSV. This will output the number of rows and columns in the CSV, the column headers in the CSV, and the [inferred](#inference) type of each column.
 
 Usage
 
@@ -265,7 +266,7 @@ Arguments:
 - `--equals` (optional, shorthand `-eq`) String to match against.
 - `--regex` (optional) Regular expression to use to match against. See [Regular Expression Syntax](#regular-expression-syntax) for the syntax.
 - `--case-insensitive` (optional, shorthand `-i`) When using the `--regex` flag, use this flag to specify a case insensitive match rather than the default case sensitive match.
-- `--gt` , `--gte`, `--lt`, `--lte` (optional) Compare against a number.
+- `--gt` , `--gte`, `--lt`, `--lte` (optional) Compare against the [inferred types int, float, datetime](#inference); booleans and strings cannot be compared.
 - `--exclude` (optional) Exclude rows that match. Default is to include.
 
 Note that one of `--regex`, `--equals` (`-eq`), `--gt` , `--gte`, `--lt`, or `--lte` must be specified.
@@ -404,7 +405,7 @@ Arguments:
 
 ### sort
 
-Sort a CSV by multiple columns, with or without type inference. The currently supported types are float, int, date, and string.
+Sort a CSV by multiple columns, with or without type [inference](#inference). The currently supported types are float, int, datetime, and string.
 
 Usage:
 
@@ -482,7 +483,7 @@ Specifying a file by name `-` will read a CSV from standard input.
 
 ### stats
 
-Get some basic statistics on a CSV.
+Get some basic statistics on a CSV, uses [inference](#inference).
 
 Usage:
 
@@ -705,6 +706,22 @@ Or, for more exotic delimiters you can use hexadecimal or unicode (e.g. `\x01` o
 export GOCSV_DELIMITER="\x01"
 gocsv select -c 1 soh-delimited.tsv
 ```
+
+## Inference
+
+GoCSV can infer values (in increasing order of precedence) for int, float, boolean, and datetime.
+
+- Ints and floats are any number that can be parsed by strconv's ParseInt and ParseFloat functions.
+
+  A column with ints and floats will be inferred as floats by the [describe](#describe) and [stats](#stats) subcommands—floats have greater precedence than ints.
+
+- Booleans are any of "T", "True", "F", or "False" (case invariant).
+
+- Datetimes are values that match any of [pkg time's](https://pkg.go.dev/time@go1.14#pkg-constants) predefined layouts, ANSIC, UnixDate, RubyDate, RFC822, RFC822Z, RFC850, RFC1123, RFC1123Z, and RFC3339 , as well as the date-only layouts, "2006-01-02", "2006-1-2", "1/2/2006", "01/02/2006".
+
+  A datetime column can have values with different layouts that match any of the previously mentioned layouts.
+
+  A custom layout can be supplied with the environment variable `GOCSV_TIMELAYOUT` (like in the GOCSV_DELIMITER examples above). Using the env var puts that layout of the "front of the line" of the precviously mentioned layouts to be tried, so the other layouts can still match values in any of the input columns.
 
 ## Examples
 

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -20,6 +20,8 @@ func (sub *DescribeSubcommand) SetFlags(fs *flag.FlagSet) {
 }
 
 func (sub *DescribeSubcommand) Run(args []string) {
+	useTimeLayoutEnvVar()
+
 	inputCsvs := GetInputCsvsOrPanic(args, 1)
 	DescribeCsv(inputCsvs[0])
 }

--- a/cmd/filter.go
+++ b/cmd/filter.go
@@ -45,6 +45,8 @@ func (sub *FilterSubcommand) SetFlags(fs *flag.FlagSet) {
 }
 
 func (sub *FilterSubcommand) Run(args []string) {
+	useTimeLayoutEnvVar()
+
 	inputCsvs := GetInputCsvsOrPanic(args, 1)
 	outputCsv := NewOutputCsvFromInputCsvs(inputCsvs)
 	sub.RunFilter(inputCsvs[0], outputCsv)

--- a/cmd/in_memory_csv.go
+++ b/cmd/in_memory_csv.go
@@ -205,6 +205,8 @@ func (imc *InMemoryCsv) PrintStatsForColumn(columnIndex int) {
 		imc.PrintStatsForColumnAsBoolean(columnIndex)
 	} else if columnType == DATE_TYPE {
 		imc.PrintStatsForColumnAsDate(columnIndex)
+	} else if columnType == DATETIME_TYPE {
+		imc.PrintStatsForColumnAsDate(columnIndex)
 	} else if columnType == STRING_TYPE {
 		imc.PrintStatsForColumnAsString(columnIndex)
 	}

--- a/cmd/sort.go
+++ b/cmd/sort.go
@@ -31,6 +31,8 @@ func (sub *SortSubcommand) SetFlags(fs *flag.FlagSet) {
 }
 
 func (sub *SortSubcommand) Run(args []string) {
+	useTimeLayoutEnvVar()
+
 	inputCsvs := GetInputCsvsOrPanic(args, 1)
 	outputCsv := NewOutputCsvFromInputCsvs(inputCsvs)
 	sub.SortCsv(inputCsvs[0], outputCsv)

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -19,6 +19,8 @@ func (sub *StatsSubcommand) SetFlags(fs *flag.FlagSet) {
 }
 
 func (sub *StatsSubcommand) Run(args []string) {
+	useTimeLayoutEnvVar()
+
 	inputCsvs := GetInputCsvsOrPanic(args, 1)
 	Stats(inputCsvs[0])
 }

--- a/cmd/types_test.go
+++ b/cmd/types_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestTimeLayoutEnvVar(t *testing.T) {
+	const layout = "06/01/02 3:04pm"
+	os.Setenv("GOCSV_TIMELAYOUT", layout)
+
+	s := "00/01/01 10:34pm"
+	want := time.Date(2000, 1, 1, 22, 34, 0, 0, time.UTC)
+
+	useTimeLayoutEnvVar()
+
+	if got, err := ParseDatetime(s); err != nil || got != want {
+		t.Errorf("ParseDatetime(%q) = %v, %v; want %v, nil", s, got, err, want)
+	}
+
+	if got, err := ParseDate(s); err != nil || got != want {
+		t.Errorf("ParseDate(%q) = %v, %v; want %v, nil", s, got, err, want)
+	}
+}


### PR DESCRIPTION
Started as the small desire to supply a custom Time layout for filtering; started going down a bit of a rabbit hole into how GoCSV deals with types.

Most changes seem straightforward, except for essentially nullifying DATE_TYPE as I moved the individual patterns vars out of ParseDate and ParseDateTime and combined them. How do you like that?

I've never thought to distinguish between date-only and datetime. I think this change simplifies the concept a bit, and moves GoCSV inline with package time.Time's view of date **and** time as a single unit.