### PR TITLE
giving delim default behavior that works w/commas

### DIFF
--- a/cmd/delimiter.go
+++ b/cmd/delimiter.go
@@ -20,10 +20,10 @@ func (sub *DelimiterSubcommand) Description() string {
 	return "Change the delimiter being used for a CSV."
 }
 func (sub *DelimiterSubcommand) SetFlags(fs *flag.FlagSet) {
-	fs.StringVar(&sub.inputDelimiter, "input", "", "Input delimiter")
-	fs.StringVar(&sub.inputDelimiter, "i", "", "Input delimiter (shorthand)")
-	fs.StringVar(&sub.outputDelimiter, "output", "", "Output delimiter")
-	fs.StringVar(&sub.outputDelimiter, "o", "", "Output delimiter (shorthand)")
+	fs.StringVar(&sub.inputDelimiter, "input", ",", "Input delimiter")
+	fs.StringVar(&sub.inputDelimiter, "i", ",", "Input delimiter (shorthand)")
+	fs.StringVar(&sub.outputDelimiter, "output", ",", "Output delimiter")
+	fs.StringVar(&sub.outputDelimiter, "o", ",", "Output delimiter (shorthand)")
 }
 
 func (sub *DelimiterSubcommand) Run(args []string) {


### PR DESCRIPTION
PR #55 was applied to issue #54. I believe that PR introduced a regression which I explain in issue #60.

This PR attempts to work with 55 by setting the default value for -i/in and -o/out flags to a comma.