### PR TITLE
Add local-build/debug version info

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,7 +80,7 @@ func usageForSubcommand(subcommand Subcommand) string {
 // Keep this in sync with the README.
 func usage() string {
 	usage := "GoCSV is a command line CSV processing tool.\n"
-	usage += version()
+	usage += version() + "\n"
 	usage += "Subcommands:\n"
 	for _, subcommand := range subcommands {
 		usage += usageForSubcommand(subcommand)
@@ -91,7 +91,7 @@ func usage() string {
 
 func version() string {
 	if VERSION != "" && GIT_HASH != "" {
-		return fmt.Sprintf("Version: %s (%s)\n", VERSION, GIT_HASH)
+		return fmt.Sprintf("Version: %s (%s)", VERSION, GIT_HASH)
 	}
 
 	s := ""
@@ -112,9 +112,9 @@ func version() string {
 			}
 		}
 	}
-	s += "local-build:  " + time.Now().Format(time.RFC3339) + "\n"
+	s += "local-build:  " + time.Now().Format(time.RFC3339)
 
-	return strings.TrimSpace(s)
+	return s
 }
 
 func Main() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
 	"runtime/debug"
 	"strings"
+	"text/tabwriter"
 	"time"
 )
 
@@ -96,25 +98,30 @@ func version() string {
 
 	s := ""
 	if bi, ok := debug.ReadBuildInfo(); ok {
-		s += "go:           " + bi.GoVersion + "\n"
+		s += "go:\t" + bi.GoVersion + "\n"
 		for _, x := range bi.Settings {
 			if x.Key == "vcs.revision" {
 				// short hash
-				s += "vcs.revision: " + x.Value[:7] + "\n"
+				s += "vcs.revision:\t" + x.Value[:7] + "\n"
 			}
 			if x.Key == "vcs.time" {
 				t, _ := time.Parse(time.RFC3339, x.Value)
 				t = t.Local()
-				s += "vcs.time:     " + t.Format(time.RFC3339) + "\n"
+				s += "vcs.time:\t" + t.Format(time.RFC3339) + "\n"
 			}
 			if x.Key == "vcs.modified" {
-				s += "vcs.modified: " + x.Value + "\n"
+				s += "vcs.modified:\t" + x.Value + "\n"
 			}
 		}
 	}
-	s += "local-build:  " + time.Now().Format(time.RFC3339)
+	s += "local-build:\t" + time.Now().Format(time.RFC3339)
 
-	return s
+	buf := &bytes.Buffer{}
+	w := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	fmt.Fprint(w, s)
+	w.Flush()
+
+	return buf.String()
 }
 
 func Main() {


### PR DESCRIPTION
I've wanted to see version info when developing locally, and #75 brought it up, too.

This change will print the normal version info for binaries built with build-bin.sh or build-dist.sh:

```shell
% ./scripts/build-bin.sh
% ./bin/gocsv version
Version: v1.0.1-25-g2359ce7 (2359ce7cea740a58e6021946d2c7fe5686b2641a)
```

and more extensive information for local/dev builds, based on go's runtime/debug [BuildInfo](https://pkg.go.dev/runtime/debug#BuildInfo) and [BuildSetting](https://pkg.go.dev/runtime/debug#BuildSetting) values:

```shell
% go build .
% ./gocsv version
go:           go1.23.4
vcs.revision: 2359ce7
vcs.time:     2025-03-21T10:15:37-07:00
vcs.modified: true
local-build:  2025-03-21T10:19:48-07:00
```

I particularly like vcs.modified informing me if the worktree was dirty at the time of build.